### PR TITLE
Use tox to test multiple versions of Python and Ansible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@ services:
 before_install:
   - sudo apt-get -qq update
 install:
+  - pip install tox-travis
   - pip install -r requirements.txt
 script:
   - ./lint.sh
-  - molecule --debug test
+  - tox
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible
+tox
 molecule
 docker
 pylint

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,3 @@ deps =
 commands =
     pip list
     molecule --debug test
-    pylint library/conda.py

--- a/tox.ini
+++ b/tox.ini
@@ -14,5 +14,4 @@ deps =
 commands =
     pip list
     pylint library/conda.py
-
-    molecule dependency
+    molecule --debug test

--- a/tox.ini
+++ b/tox.ini
@@ -13,5 +13,5 @@ deps =
     ansibledevel: git+https://github.com/ansible/ansible.git
 commands =
     pip list
-    pylint library/conda.py
     molecule --debug test
+    pylint library/conda.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+minversion = 1.8
+envlist = py{36,37,27}-ansible{26,27,devel}
+skipsdist = true
+skip_missing_interpreters = True
+
+[testenv]
+passenv = *
+deps =
+    -rrequirements.txt
+    ansible26: ansible>=2.6,<2.7
+    ansible27: ansible>=2.7,<2.8
+    ansibledevel: git+https://github.com/ansible/ansible.git
+commands =
+    pip list
+    pylint library/conda.py
+
+    molecule dependency

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = py{27,36,37}-ansible{26,27,devel}
+envlist = py{27,36,37}-ansible{26,27}
 skipsdist = true
 skip_missing_interpreters = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = py{36,37,27}-ansible{26,27,devel}
+envlist = py{27,36,37}-ansible{26,27,devel}
 skipsdist = true
 skip_missing_interpreters = True
 


### PR DESCRIPTION
I like your role, but is should still work when running under python3 and with the current set of Ansible versions out there (2.6, 2.7) the upcoming ansible should work as well.

Tox allows us to test this. 

```
pip install tox
cd evandam.conda
tox
```


